### PR TITLE
Add partial INT8 QAT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ By [MC2 Lab](http://buaamc2.net/) @ [Beihang University](http://ev.buaa.edu.cn/)
  
 ## Dependencies and Installation
 - Python 3 (Recommend to use [Anaconda](https://www.anaconda.com/download/#linux)).
-- [PyTorch = 1.0.1](https://pytorch.org/) .
-- See [environment.yml](https://github.com/TomTomTommi/HiNet/blob/main/environment.yml) for other dependencies.
+- [PyTorch >= 2.7.1+cu118](https://pytorch.org/).
+- See `environment_torch2.yml` for a sample conda environment with this version.
 
 
 ## Get Started
@@ -43,8 +43,21 @@ By [MC2 Lab](http://buaamc2.net/) @ [Beihang University](http://ev.buaa.edu.cn/)
 
 - Fill in the `MODEL_PATH` and the file name `suffix` before testing by the trained model.
 
-- For example, if the model name is `model.pt` and its path is `/home/usrname/Hinet/model/`, 
+- For example, if the model name is `model.pt` and its path is `/home/usrname/Hinet/model/`,
 set `MODEL_PATH = '/home/usrname/Hinet/model/'` and file name `suffix = 'model.pt'`.
+
+## Partial INT8 Quantization
+The script `qat_partial.py` demonstrates how to apply mixed precision
+quantization aware training (QAT). All `nn.Conv2d` layers are quantized while
+the `INV_block` modules remain in full precision. After a short calibration the
+script exports `hinet_qat_int8.pth` which can be deployed on devices such as
+Raspberry Pi.
+
+Run the example:
+
+```bash
+python qat_partial.py
+```
 
 
 ## Training Demo (2021/12/25 Updated)

--- a/environment_torch2.yml
+++ b/environment_torch2.yml
@@ -1,0 +1,18 @@
+name: hinet_pytorch2
+channels:
+  - pytorch
+  - nvidia
+  - defaults
+dependencies:
+  - python=3.10
+  - pytorch=2.7.1
+  - torchvision=0.18.1
+  - torchaudio=2.7.1
+  - cudatoolkit=11.8
+  - pip
+  - pip:
+      - matplotlib
+      - numpy
+      - opencv-python
+      - tqdm
+

--- a/qat_partial.py
+++ b/qat_partial.py
@@ -1,0 +1,56 @@
+import torch
+import torch.nn as nn
+import torch.ao.quantization as tq
+
+from hinet import Hinet
+from invblock import INV_block
+
+
+def mark_quant_layers(module):
+    for name, child in module.named_children():
+        if isinstance(child, INV_block):
+            # Do not quantize inside invertible blocks
+            continue
+        if isinstance(child, nn.Conv2d):
+            child.qconfig = tq.get_default_qat_qconfig('fbgemm')
+        else:
+            mark_quant_layers(child)
+
+
+def prepare_model_for_qat(model):
+    mark_quant_layers(model)
+    tq.prepare_qat(model, inplace=True)
+
+
+def calibrate(model, steps=8):
+    model.train()
+    for _ in range(steps):
+        dummy = torch.randn(1, 3, 64, 64)
+        model(dummy)
+
+
+def convert(model):
+    model.eval()
+    quantized = tq.convert(model.eval(), inplace=False)
+    return quantized
+
+
+def main():
+    model = Hinet()
+    prepare_model_for_qat(model)
+
+    # Fake train loop
+    for _ in range(2):
+        data = torch.randn(1, 3, 64, 64)
+        out = model(data)
+        loss = out.abs().mean()
+        loss.backward()
+
+    calibrate(model)
+    qmodel = convert(model)
+    torch.save(qmodel.state_dict(), 'hinet_qat_int8.pth')
+    print('quantized model saved')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- document how to run a mixed precision training demo
- provide `qat_partial.py` that prepares the model for QAT and exports an INT8 checkpoint
- explain how to create a conda environment with PyTorch 2.7.1+cu118

## Testing
- `python3 -m py_compile qat_partial.py`
- `python3 qat_partial.py` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_687a077af47c832cb2ff89a114cefe12