### PR TITLE
Fix dataset file validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@
 clamp = 2.0
 channels_in = 3
 log10_lr = -4.5
-lr = 10 ** log10_lr
+lr = 10**log10_lr
 epochs = 1000
 weight_decay = 1e-5
 init_scale = 0.01
@@ -26,30 +26,31 @@ shuffle_val = False
 val_freq = 50
 
 # Dataset
-TRAIN_PATH = './data/DIV2K_train_HR/'
-VAL_PATH = './data/DIV2K_valid_HR/'
-format_train = 'png'
-format_val = 'png'
+TRAIN_PATH = "./data/DIV2K_train_HR/"
+VAL_PATH = "./data/DIV2K_valid_HR/"
+format_train = "png"
+format_val = "png"
+train_limit = 80  # limit number of training images to reduce resource usage
 
 # Display and logging:
 loss_display_cutoff = 2.0
-loss_names = ['L', 'lr']
+loss_names = ["L", "lr"]
 silent = False
 live_visualization = False
 progress_bar = False
 
 # Saving checkpoints:
-MODEL_PATH = './model/'
+MODEL_PATH = "./model/"
 checkpoint_on_error = True
 SAVE_freq = 50
 
-IMAGE_PATH = './image/'
-IMAGE_PATH_cover = IMAGE_PATH + 'cover/'
-IMAGE_PATH_secret = IMAGE_PATH + 'secret/'
-IMAGE_PATH_steg = IMAGE_PATH + 'steg/'
-IMAGE_PATH_secret_rev = IMAGE_PATH + 'secret-rev/'
+IMAGE_PATH = "./image/"
+IMAGE_PATH_cover = IMAGE_PATH + "cover/"
+IMAGE_PATH_secret = IMAGE_PATH + "secret/"
+IMAGE_PATH_steg = IMAGE_PATH + "steg/"
+IMAGE_PATH_secret_rev = IMAGE_PATH + "secret-rev/"
 
 # Load:
-suffix = 'model.pt'
+suffix = "model.pt"
 tain_next = False
 trained_epoch = 0


### PR DESCRIPTION
## Summary
- skip unreadable image files at dataset initialization to avoid index errors
- limit the number of training images to 80 to reduce resource use

## Testing
- `ruff check datasets.py config.py`
- `black config.py datasets.py --line-length 79`
- `python -m py_compile datasets.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_687bb46c51e4832cba5a91941c08c708