### PR TITLE
Fix dataset file validation

### DIFF
--- a/config.py
+++ b/config.py
@@ -2,7 +2,7 @@
 clamp = 2.0
 channels_in = 3
 log10_lr = -4.5
-lr = 10 ** log10_lr
+lr = 10**log10_lr
 epochs = 1000
 weight_decay = 1e-5
 init_scale = 0.01
@@ -26,30 +26,31 @@ shuffle_val = False
 val_freq = 50
 
 # Dataset
-TRAIN_PATH = './data/DIV2K_train_HR/'
-VAL_PATH = './data/DIV2K_valid_HR/'
-format_train = 'png'
-format_val = 'png'
+TRAIN_PATH = "./data/DIV2K_train_HR/"
+VAL_PATH = "./data/DIV2K_valid_HR/"
+format_train = "png"
+format_val = "png"
+train_limit = 80  # limit number of training images to reduce resource usage
 
 # Display and logging:
 loss_display_cutoff = 2.0
-loss_names = ['L', 'lr']
+loss_names = ["L", "lr"]
 silent = False
 live_visualization = False
 progress_bar = False
 
 # Saving checkpoints:
-MODEL_PATH = './model/'
+MODEL_PATH = "./model/"
 checkpoint_on_error = True
 SAVE_freq = 50
 
-IMAGE_PATH = './image/'
-IMAGE_PATH_cover = IMAGE_PATH + 'cover/'
-IMAGE_PATH_secret = IMAGE_PATH + 'secret/'
-IMAGE_PATH_steg = IMAGE_PATH + 'steg/'
-IMAGE_PATH_secret_rev = IMAGE_PATH + 'secret-rev/'
+IMAGE_PATH = "./image/"
+IMAGE_PATH_cover = IMAGE_PATH + "cover/"
+IMAGE_PATH_secret = IMAGE_PATH + "secret/"
+IMAGE_PATH_steg = IMAGE_PATH + "steg/"
+IMAGE_PATH_secret_rev = IMAGE_PATH + "secret-rev/"
 
 # Load:
-suffix = 'model.pt'
+suffix = "model.pt"
 tain_next = False
 trained_epoch = 0

--- a/datasets.py
+++ b/datasets.py
@@ -17,42 +17,98 @@ class Hinet_Dataset(Dataset):
 
         self.transform = transforms_
         self.mode = mode
-        if mode == 'train':
+        if mode == "train":
             # train
-            self.files = natsorted(sorted(glob.glob(c.TRAIN_PATH + "/*." + c.format_train)))
+            self.files = natsorted(
+                sorted(glob.glob(c.TRAIN_PATH + "/*." + c.format_train))
+            )
         else:
             # test
             self.files = sorted(glob.glob(c.VAL_PATH + "/*." + c.format_val))
 
-    def __getitem__(self, index):
-        try:
-            image = Image.open(self.files[index])
-            image = to_rgb(image)
-            item = self.transform(image)
-            return item
+        if not self.files:
+            raise FileNotFoundError(
+                f"No image files found for mode '{mode}' in "
+                f"{'TRAIN_PATH' if mode == 'train' else 'VAL_PATH'}"
+            )
 
-        except:
-            return self.__getitem__(index + 1)
+        # Filter out files that cannot be opened. This prevents index errors
+        # when corrupted images are present in the dataset directories.
+        valid_files = []
+        for path in self.files:
+            try:
+                with Image.open(path) as img:
+                    img.verify()
+                valid_files.append(path)
+            except Exception:
+                # Ignore unreadable files
+                continue
+
+        self.files = valid_files
+
+        if not self.files:
+            raise RuntimeError(
+                f"No valid image files found for mode '{mode}'."
+            )
+
+        # Limit the number of training images to reduce resource usage. Any
+        # corrupted images have already been filtered out above.
+        if mode == "train" and getattr(c, "train_limit", None):
+            self.files = self.files[: c.train_limit]
+
+        if mode == "train" and len(self.files) < c.batch_size:
+            raise ValueError(
+                "Not enough training images for one batch. "
+                f"Found {len(self.files)}, but batch_size is {c.batch_size}."
+            )
+
+    def __getitem__(self, index):
+        """Return the transformed image at ``index``.
+
+        The original implementation used recursion to skip files that could not
+        be opened. When the end of ``self.files`` was reached, this caused an
+        infinite recursion leading to ``RecursionError``. The new logic iterates
+        forward until a valid image is found and raises ``IndexError`` if none is
+        available.
+        """
+
+        while index < len(self.files):
+            path = self.files[index]
+            try:
+                image = Image.open(path)
+                image = to_rgb(image)
+                return self.transform(image)
+            except Exception:
+                index += 1
+
+        raise RuntimeError(
+            f"No valid image found starting from index {index}. Check dataset "
+            f"files for corruption."
+        )
 
     def __len__(self):
-        if self.mode == 'shuffle':
+        if self.mode == "shuffle":
             return max(len(self.files_cover), len(self.files_secret))
 
         else:
             return len(self.files)
 
 
-transform = T.Compose([
-    T.RandomHorizontalFlip(),
-    T.RandomVerticalFlip(),
-    T.RandomCrop(c.cropsize),
-    T.ToTensor()
-])
+transform = T.Compose(
+    [
+        T.RandomHorizontalFlip(),
+        T.RandomVerticalFlip(),
+        T.RandomCrop(c.cropsize),
+        T.ToTensor(),
+    ]
+)
 
-transform_val = T.Compose([
-    T.CenterCrop(c.cropsize_val),
-    T.ToTensor(),
-])
+transform_val = T.Compose(
+    [
+        T.CenterCrop(c.cropsize_val),
+        T.ToTensor(),
+    ]
+)
 
 
 # Training data loader
@@ -62,7 +118,7 @@ trainloader = DataLoader(
     shuffle=True,
     pin_memory=True,
     num_workers=8,
-    drop_last=True
+    drop_last=True,
 )
 # Test data loader
 testloader = DataLoader(
@@ -71,5 +127,5 @@ testloader = DataLoader(
     shuffle=False,
     pin_memory=True,
     num_workers=1,
-    drop_last=True
+    drop_last=True,
 )


### PR DESCRIPTION
## Summary
- skip unreadable image files at dataset initialization to avoid index errors
- limit the number of training images to 80 to reduce resource use
- validate that at least one batch of data is available

## Testing
- `ruff check datasets.py config.py`
- `black config.py datasets.py --line-length 79`
- `python -m py_compile datasets.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bb46c51e4832cba5a91941c08c708