### PR TITLE
Track QAT metrics during training

### DIFF
--- a/qat_partial.py
+++ b/qat_partial.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 import numpy as np
 import os
 from datetime import datetime
+import matplotlib.pyplot as plt
 
 from hinet import Hinet
 from invblock import INV_block
@@ -71,8 +72,14 @@ def load_pretrained(model, path=None):
     print(f"loaded pretrained weights from {path}")
 
 
-def train(model, epochs=1):
-    """Train the network with partial QAT for several epochs."""
+def train(model, epochs=1, metrics=None):
+    """Train the network with partial QAT for several epochs.
+
+    Args:
+        model: network to train.
+        epochs: number of epochs.
+        metrics: optional dict to store loss and PSNR per epoch.
+    """
     optim = torch.optim.Adam(model.parameters(), lr=c.lr)
     dwt = common.DWT().to(device)
     iwt = common.IWT().to(device)
@@ -118,10 +125,21 @@ def train(model, epochs=1):
 
         avg = epoch_loss / max(1, len(datasets.trainloader))
         print(f"epoch {epoch + 1}: loss {avg:.6f}")
+        if metrics is not None:
+            metrics.setdefault("loss", []).append(avg)
+            ps_cover, ps_secret = evaluate(model, silent=True)
+            metrics.setdefault("psnr_train_cover", []).append(ps_cover)
+            metrics.setdefault("psnr_train_secret", []).append(ps_secret)
 
 
-def calibrate(model, steps=5):
-    """Run a short calibration on a few training batches."""
+def calibrate(model, steps=5, metrics=None):
+    """Run a short calibration on a few training batches.
+
+    Args:
+        model: model to calibrate.
+        steps: number of calibration batches.
+        metrics: optional dict to record PSNR after each step.
+    """
     model.eval()
     dwt = common.DWT().to(device)
     loader = iter(datasets.trainloader)
@@ -140,6 +158,10 @@ def calibrate(model, steps=5):
             assert input_img.size(1) == 24, f"expected 24 channels, got {input_img.size(1)}"
 
             model(input_img)
+            if metrics is not None:
+                ps_cover, ps_secret = evaluate(model, silent=True)
+                metrics.setdefault("psnr_calib_cover", []).append(ps_cover)
+                metrics.setdefault("psnr_calib_secret", []).append(ps_secret)
 
 def convert(model):
     model.cpu()
@@ -153,17 +175,32 @@ def psnr(img1, img2):
     return 10 * torch.log10(1.0 / mse).item()
 
 
-def evaluate(model):
+def evaluate(model, silent=False):
     dwt = common.DWT().to(device)
     iwt = common.IWT().to(device)
     model.eval()
     scores_cover = []
     scores_secret = []
+
+    def pair_batches(loader):
+        """Yield image pairs regardless of original batch size."""
+        buffer = []
+        for batch in loader:
+            if batch.ndim == 3:
+                batch = batch.unsqueeze(0)
+            for img in batch:
+                buffer.append(img)
+                if len(buffer) == 2:
+                    yield torch.stack(buffer, 0)
+                    buffer = []
+        if buffer:
+            print("Warning: ignoring the last image without a pair")
+
     with torch.no_grad():
-        for data in datasets.testloader:
-            data = data.to(device)
-            cover = data[data.size(0) // 2 :]
-            secret = data[: data.size(0) // 2]
+        for batch in pair_batches(datasets.testloader):
+            batch = batch.to(device)
+            cover = batch[1:]
+            secret = batch[:1]
             cover_in = dwt(cover)
             secret_in = dwt(secret)
             input_img = torch.cat((cover_in, secret_in), 1)
@@ -178,15 +215,59 @@ def evaluate(model):
 
     mean_cover = float(np.mean(scores_cover))
     mean_secret = float(np.mean(scores_secret))
-    print(f"PSNR cover: {mean_cover:.2f} dB, secret: {mean_secret:.2f} dB")
+    if not silent:
+        print(f"PSNR cover: {mean_cover:.2f} dB, secret: {mean_secret:.2f} dB")
+    return mean_cover, mean_secret
+
+
+def plot_metrics(metrics, timestamp):
+    os.makedirs("logging", exist_ok=True)
+    np.savez(os.path.join("logging", f"qat_metrics_{timestamp}.npz"), **metrics)
+
+    if metrics.get("loss"):
+        plt.figure()
+        plt.plot(range(1, len(metrics["loss"]) + 1), metrics["loss"], label="loss")
+        plt.xlabel("Epoch")
+        plt.ylabel("Loss")
+        plt.title("Training Loss")
+        plt.grid(True)
+        plt.savefig(os.path.join("logging", f"loss_{timestamp}.png"))
+        plt.close()
+
+    if metrics.get("psnr_train_cover"):
+        plt.figure()
+        epochs = range(1, len(metrics["psnr_train_cover"]) + 1)
+        plt.plot(epochs, metrics["psnr_train_cover"], label="cover")
+        plt.plot(epochs, metrics["psnr_train_secret"], label="secret")
+        plt.xlabel("Epoch")
+        plt.ylabel("PSNR (dB)")
+        plt.title("Training PSNR")
+        plt.legend()
+        plt.grid(True)
+        plt.savefig(os.path.join("logging", f"psnr_train_{timestamp}.png"))
+        plt.close()
+
+    if metrics.get("psnr_calib_cover"):
+        plt.figure()
+        steps = range(1, len(metrics["psnr_calib_cover"]) + 1)
+        plt.plot(steps, metrics["psnr_calib_cover"], label="cover")
+        plt.plot(steps, metrics["psnr_calib_secret"], label="secret")
+        plt.xlabel("Calibration step")
+        plt.ylabel("PSNR (dB)")
+        plt.title("Calibration PSNR")
+        plt.legend()
+        plt.grid(True)
+        plt.savefig(os.path.join("logging", f"psnr_calib_{timestamp}.png"))
+        plt.close()
 
 
 def main(pretrained=None, epochs=1, calib_steps=5):
+    metrics = {}
     model = Hinet().to(device)
     load_pretrained(model, pretrained)
     prepare_model_for_qat(model)
-    train(model, epochs=epochs)
-    calibrate(model, steps=calib_steps)
+    train(model, epochs=epochs, metrics=metrics)
+    calibrate(model, steps=calib_steps, metrics=metrics)
     qmodel = convert(model)
     evaluate(qmodel.to(device))
     os.makedirs("model", exist_ok=True)
@@ -194,6 +275,7 @@ def main(pretrained=None, epochs=1, calib_steps=5):
     save_path = os.path.join("model", f"model_qat_{timestamp}.pt")
     torch.save(qmodel.state_dict(), save_path)
     print(f"quantized model saved to {save_path}")
+    plot_metrics(metrics, timestamp)
 
 
 if __name__ == "__main__":

--- a/run_quantized.py
+++ b/run_quantized.py
@@ -1,0 +1,203 @@
+import argparse
+import glob
+import os
+import torch
+import torch.nn as nn
+import torch.ao.quantization as tq
+import torchvision.utils as vutils
+import numpy as np
+import cv2
+
+from hinet import Hinet
+from invblock import INV_block
+import modules.Unet_common as common
+import datasets
+import config as c
+
+
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+
+def mark_quant_layers(module: nn.Module):
+    for child in module.children():
+        if isinstance(child, INV_block):
+            continue
+        if isinstance(child, nn.Conv2d):
+            child.qconfig = tq.get_default_qat_qconfig("fbgemm")
+        mark_quant_layers(child)
+
+
+def load_quantized(model_path: str) -> nn.Module:
+    model = Hinet()
+    mark_quant_layers(model)
+    tq.prepare_qat(model, inplace=True)
+    model = tq.convert(model.eval(), inplace=True)
+    state = torch.load(model_path, map_location=device)
+    model.load_state_dict(state)
+    model.to(device)
+    model.eval()
+    return model
+
+
+def pair_batches(loader):
+    buffer = []
+    for batch in loader:
+        if batch.ndim == 3:
+            batch = batch.unsqueeze(0)
+        for img in batch:
+            buffer.append(img)
+            if len(buffer) == 2:
+                yield torch.stack(buffer, 0)
+                buffer = []
+    if buffer:
+        print("Warning: ignoring the last image without a pair")
+
+
+def gauss_noise(shape):
+    return torch.randn(shape, device=device)
+
+
+def psnr(img1: torch.Tensor, img2: torch.Tensor) -> float:
+    mse = torch.mean((img1 - img2) ** 2)
+    if mse == 0:
+        return float("inf")
+    return 10 * torch.log10(1.0 / mse).item()
+
+
+def bgr2ycbcr(img: np.ndarray, only_y: bool = True) -> np.ndarray:
+    in_img_type = img.dtype
+    img = img.astype(np.float32)
+    if in_img_type != np.uint8:
+        img *= 255.0
+    if only_y:
+        rlt = np.dot(img, [24.966, 128.553, 65.481]) / 255.0 + 16.0
+    else:
+        rlt = (
+            np.matmul(
+                img,
+                [
+                    [24.966, 112.0, -18.214],
+                    [128.553, -74.203, -93.786],
+                    [65.481, -37.797, 112.0],
+                ],
+            )
+            / 255.0
+            + [16, 128, 128]
+        )
+    if in_img_type == np.uint8:
+        rlt = rlt.round()
+    else:
+        rlt /= 255.0
+    return rlt.astype(in_img_type)
+
+
+def ssim(img1: np.ndarray, img2: np.ndarray) -> float:
+    C1 = (0.01 * 255) ** 2
+    C2 = (0.03 * 255) ** 2
+
+    img1 = img1.astype(np.float64)
+    img2 = img2.astype(np.float64)
+    kernel = cv2.getGaussianKernel(11, 1.5)
+    window = np.outer(kernel, kernel.transpose())
+
+    mu1 = cv2.filter2D(img1, -1, window)[5:-5, 5:-5]
+    mu2 = cv2.filter2D(img2, -1, window)[5:-5, 5:-5]
+    mu1_sq = mu1**2
+    mu2_sq = mu2**2
+    mu1_mu2 = mu1 * mu2
+    sigma1_sq = cv2.filter2D(img1**2, -1, window)[5:-5, 5:-5] - mu1_sq
+    sigma2_sq = cv2.filter2D(img2**2, -1, window)[5:-5, 5:-5] - mu2_sq
+    sigma12 = cv2.filter2D(img1 * img2, -1, window)[5:-5, 5:-5] - mu1_mu2
+
+    ssim_map = ((2 * mu1_mu2 + C1) * (2 * sigma12 + C2)) / (
+        (mu1_sq + mu2_sq + C1) * (sigma1_sq + sigma2_sq + C2)
+    )
+    return ssim_map.mean()
+
+
+def calculate_ssim(img1: np.ndarray, img2: np.ndarray) -> float:
+    if img1.shape != img2.shape:
+        raise ValueError("Input images must have the same dimensions")
+    if img1.ndim == 2:
+        return ssim(img1, img2)
+    elif img1.ndim == 3:
+        if img1.shape[2] == 3:
+            return np.mean([ssim(img1[..., i], img2[..., i]) for i in range(3)])
+        elif img1.shape[2] == 1:
+            return ssim(img1.squeeze(), img2.squeeze())
+    else:
+        raise ValueError("Wrong input image dimensions")
+
+
+def run(model: nn.Module):
+    dwt = common.DWT().to(device)
+    iwt = common.IWT().to(device)
+    loader = pair_batches(datasets.testloader)
+    psnr_cover_scores = []
+    psnr_secret_scores = []
+    ssim_cover_scores = []
+    ssim_secret_scores = []
+    with torch.no_grad():
+        for i, batch in enumerate(loader):
+            batch = batch.to(device)
+            cover = batch[1:]
+            secret = batch[:1]
+            cover_in = dwt(cover)
+            secret_in = dwt(secret)
+            input_img = torch.cat((cover_in, secret_in), 1)
+            output = model(input_img)
+            output_steg = output.narrow(1, 0, 4 * c.channels_in)
+            output_z = output.narrow(1, 4 * c.channels_in, output.shape[1] - 4 * c.channels_in)
+            steg_img = iwt(output_steg)
+            backward_z = gauss_noise(output_z.shape)
+            rev_input = torch.cat((output_steg, backward_z), 1)
+            backward = model(rev_input, rev=True)
+            secret_rev = iwt(backward.narrow(1, 4 * c.channels_in, backward.shape[1] - 4 * c.channels_in))
+
+            # save images
+            vutils.save_image(cover, os.path.join(c.IMAGE_PATH_cover, f"{i:05d}.png"))
+            vutils.save_image(secret, os.path.join(c.IMAGE_PATH_secret, f"{i:05d}.png"))
+            vutils.save_image(steg_img, os.path.join(c.IMAGE_PATH_steg, f"{i:05d}.png"))
+            vutils.save_image(secret_rev, os.path.join(c.IMAGE_PATH_secret_rev, f"{i:05d}.png"))
+
+            # metrics in Y channel
+            cover_np = cover.squeeze(0).permute(1, 2, 0).cpu().numpy()
+            steg_np = steg_img.squeeze(0).permute(1, 2, 0).cpu().numpy()
+            secret_np = secret.squeeze(0).permute(1, 2, 0).cpu().numpy()
+            rev_np = secret_rev.squeeze(0).permute(1, 2, 0).cpu().numpy()
+
+            cover_y = bgr2ycbcr(cover_np, only_y=True)
+            steg_y = bgr2ycbcr(steg_np, only_y=True)
+            secret_y = bgr2ycbcr(secret_np, only_y=True)
+            rev_y = bgr2ycbcr(rev_np, only_y=True)
+
+            psnr_cover_scores.append(psnr(steg_img, cover))
+            psnr_secret_scores.append(psnr(secret_rev, secret))
+            ssim_cover_scores.append(calculate_ssim(cover_y, steg_y))
+            ssim_secret_scores.append(calculate_ssim(secret_y, rev_y))
+
+    print(
+        f"PSNR cover: {np.mean(psnr_cover_scores):.2f} dB, secret: {np.mean(psnr_secret_scores):.2f} dB"
+    )
+    print(
+        f"SSIM cover: {np.mean(ssim_cover_scores):.4f}, secret: {np.mean(ssim_secret_scores):.4f}"
+    )
+
+def main(model_path: str):
+    model = load_quantized(model_path)
+    run(model)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run quantized HiNet model for testing")
+    parser.add_argument("--model", type=str, default=None, help="path to quantized model")
+    args = parser.parse_args()
+
+    if args.model is None:
+        files = sorted(glob.glob(os.path.join("model", "model_qat_*.pt")))
+        if not files:
+            raise FileNotFoundError("No quantized model found in ./model")
+        args.model = files[-1]
+        print(f"loading latest model {args.model}")
+
+    main(args.model)


### PR DESCRIPTION
## Summary
- log average loss and PSNR during QAT training and calibration
- save metrics to `logging/` and plot them as PNG graphs

## Testing
- `python -m py_compile run_quantized.py demo_quantized.py qat_partial.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688088c19434832c9a17bf26ca6b88d4